### PR TITLE
fix: 处理mysql密码为数字如123456

### DIFF
--- a/config/config.php
+++ b/config/config.php
@@ -95,7 +95,7 @@ return [
                 'host' => env("MYSQL_HOST"),
                 'port' => env("MYSQL_PORT"),
                 'username' => env("MYSQL_USERNAME"),
-                'password' => env("MYSQL_PASSWORD"),
+                'password' => (string)env("MYSQL_PASSWORD"),
                 'database' => env("MYSQL_DATABASE"),
                 'charset' => 'utf8mb4',
             ],


### PR DESCRIPTION
 TypeError: PDO::__construct(): Argument #3 ($password) must be of type ?string, int given in /mnt/d/amp/www/swoole/imi/imi-admin/vendor/imiphp/imi/src/Db/Mysql/Drivers/PdoMysql/Driver.php: